### PR TITLE
feat: no destr state obj when addr matches cc pc

### DIFF
--- a/concrete/concrete_test.go
+++ b/concrete/concrete_test.go
@@ -73,7 +73,6 @@ func TestPrecompile(t *testing.T) {
 				gspec = &core.Genesis{
 					Config: params.TestChainConfig,
 					Alloc: core.GenesisAlloc{
-						impl.address:  {Balance: common.Big1},
 						senderAddress: {Balance: big.NewInt(1000000000000000)},
 					},
 				}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1084,7 +1084,8 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 			// Thus, we can safely ignore it here
 			continue
 		}
-		if obj.suicided || (deleteEmptyObjects && obj.empty()) {
+		_, isConcretePrecompile := cc_contracts.GetPrecompile(addr)
+		if obj.suicided || (deleteEmptyObjects && obj.empty() && !isConcretePrecompile) {
 			obj.deleted = true
 
 			// We need to maintain account deletions explicitly (will remain


### PR DESCRIPTION
Concrete precompile state objects are treated as empty during finalisation as their nonce, balance, and codeHash are zero/empty.
This PR adds a check on the address of objects being finalised and treats them as non-empty if it matches that of a precompile.