### PR TITLE
Preimage registry config

### DIFF
--- a/concrete/main.go
+++ b/concrete/main.go
@@ -28,10 +28,16 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+type ConcreteConfig struct {
+	PreimageRegistryConfig    precompiles.PreimageRegistryConfig
+	BigPreimageRegistryConfig precompiles.PreimageRegistryConfig
+}
+
 type ConcreteApp interface {
 	RunWithArgs(args []string) error
 	RunWithOsArgs() error
 	Run() error
+	SetConfig(config ConcreteConfig) error
 	AddPrecompile(addr common.Address, pc api.Precompile, args ...interface{}) error
 	AddPrecompileWasm(addr common.Address, code []byte, args ...interface{}) error
 }
@@ -54,6 +60,12 @@ func (a *concreteGeth) RunWithOsArgs() error {
 
 func (a *concreteGeth) Run() error {
 	return a.RunWithOsArgs()
+}
+
+func (a *concreteGeth) SetConfig(config ConcreteConfig) error {
+	precompiles.PreimageRegistry.SetConfig(config.PreimageRegistryConfig)
+	precompiles.BigPreimageRegistry.SetConfig(config.BigPreimageRegistryConfig)
+	return nil
 }
 
 func (a *concreteGeth) validateNewPCAddress(addr common.Address) error {

--- a/concrete/precompiles/precompile_registry.go
+++ b/concrete/precompiles/precompile_registry.go
@@ -28,11 +28,7 @@ import (
 //go:embed sol/abi/PrecompileRegistry.abi
 var precompileRegistryABI string
 
-type FrameworkMetadata = struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	Source  string `json:"source"`
-}
+var PrecompileRegistry *lib.PrecompileWithABI
 
 var PrecompileRegistryMetadata = PrecompileMetadata{
 	Name:        "PrecompileRegistry",
@@ -56,14 +52,20 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	precompileRegistry := lib.NewPrecompileWithABI(ABI, map[string]lib.MethodPrecompile{
+	PrecompileRegistry := lib.NewPrecompileWithABI(ABI, map[string]lib.MethodPrecompile{
 		"getFramework":            &getFramework{},
 		"getPrecompile":           &getPrecompile{},
 		"getPrecompileByName":     &getPrecompileByName{},
 		"getPrecompiledAddresses": &getPrecompiledAddresses{},
 		"getPrecompiles":          &getPrecompiles{},
 	})
-	AddPrecompile(api.PrecompileRegistryAddress, precompileRegistry, PrecompileRegistryMetadata)
+	AddPrecompile(api.PrecompileRegistryAddress, PrecompileRegistry, PrecompileRegistryMetadata)
+}
+
+type FrameworkMetadata = struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Source  string `json:"source"`
 }
 
 type getFramework struct {


### PR DESCRIPTION
This PR allows configuring (dis/enable registry, dis/enable writes) the built-in preimage registries from the `ConcreteGeth` object.