### PR TITLE
Non-0 fail gas

### DIFF
--- a/concrete/lib/precompile_utils.go
+++ b/concrete/lib/precompile_utils.go
@@ -21,6 +21,8 @@ import (
 	"github.com/ethereum/go-ethereum/concrete/api"
 )
 
+var FailGas = uint64(10)
+
 type BlankPrecompile struct{}
 
 func (pc *BlankPrecompile) MutatesStorage(input []byte) bool {
@@ -68,7 +70,7 @@ func (d PrecompileDemux) MutatesStorage(input []byte) bool {
 func (d PrecompileDemux) RequiredGas(input []byte) uint64 {
 	pc, input, err := d.getSelection(input)
 	if err != nil {
-		return 0
+		return FailGas
 	}
 	return pc.RequiredGas(input)
 }

--- a/concrete/lib/precompile_utils_go.go
+++ b/concrete/lib/precompile_utils_go.go
@@ -52,7 +52,7 @@ func (p *BlankMethodPrecompile) MutatesStorage(input []byte) bool {
 func (p *BlankMethodPrecompile) CallRequiredGasWithArgs(requiredGas func(args []interface{}) uint64, input []byte) uint64 {
 	args, err := p.Method.Inputs.UnpackValues(input)
 	if err != nil {
-		return 0
+		return FailGas
 	}
 	return requiredGas(args)
 }
@@ -117,7 +117,7 @@ func (p *PrecompileWithABI) MutatesStorage(input []byte) bool {
 func (p *PrecompileWithABI) RequiredGas(input []byte) uint64 {
 	pc, input, err := p.getMethod(input)
 	if err != nil {
-		return 0
+		return FailGas
 	}
 	return pc.RequiredGas(input)
 }

--- a/concrete/lib/precompile_utils_go.go
+++ b/concrete/lib/precompile_utils_go.go
@@ -32,16 +32,16 @@ func MethodIDToKey(methodID []byte) MethodIDKey {
 
 type MethodPrecompile interface {
 	api.Precompile
-	Init(parent *PrecompileWithABI, method *abi.Method)
+	Init(parent *PrecompileWithABI, method abi.Method)
 }
 
 type BlankMethodPrecompile struct {
 	BlankPrecompile
-	Method *abi.Method
 	Parent *PrecompileWithABI
+	Method abi.Method
 }
 
-func (p *BlankMethodPrecompile) Init(parent *PrecompileWithABI, method *abi.Method) {
+func (p *BlankMethodPrecompile) Init(parent *PrecompileWithABI, method abi.Method) {
 	p.Method = method
 }
 
@@ -90,7 +90,7 @@ func NewPrecompileWithABI(contractABI abi.ABI, methods map[string]MethodPrecompi
 		if !ok {
 			panic("missing implementation for " + name)
 		}
-		impl.Init(p, &method)
+		impl.Init(p, method)
 		p.Methods[MethodIDToKey(method.ID)] = impl
 	}
 	return p

--- a/concrete/precompiles/preimage_registry.go
+++ b/concrete/precompiles/preimage_registry.go
@@ -137,7 +137,7 @@ func NewPreimageRegistry(ABI abi.ABI, getStore func(api.API) api.PreimageStore, 
 		Config:   config,
 		GasTable: gasTable,
 	}
-	registryMethod := blankRegistryMethod{registry: registry}
+	registryMethod := blankPreimageRegistryMethod{registry: registry}
 	registry.PrecompileWithABI = *lib.NewPrecompileWithABI(ABI, map[string]lib.MethodPrecompile{
 		"addPreimage":     &addPreimage{registryMethod},
 		"hasPreimage":     &hasPreimage{registryMethod},
@@ -165,13 +165,13 @@ func (p *PreimageRegistryPrecompile) Run(API api.API, input []byte) ([]byte, err
 	return p.PrecompileWithABI.Run(API, input)
 }
 
-type blankRegistryMethod struct {
+type blankPreimageRegistryMethod struct {
 	lib.BlankMethodPrecompile
 	registry *PreimageRegistryPrecompile
 }
 
 type addPreimage struct {
-	blankRegistryMethod
+	blankPreimageRegistryMethod
 }
 
 func (p *addPreimage) RequiredGas(input []byte) uint64 {
@@ -196,7 +196,7 @@ func (p *addPreimage) Run(API api.API, input []byte) ([]byte, error) {
 }
 
 type hasPreimage struct {
-	blankRegistryMethod
+	blankPreimageRegistryMethod
 }
 
 func (p *hasPreimage) RequiredGas(input []byte) uint64 {
@@ -212,7 +212,7 @@ func (p *hasPreimage) Run(API api.API, input []byte) ([]byte, error) {
 }
 
 type getPreimageSize struct {
-	blankRegistryMethod
+	blankPreimageRegistryMethod
 }
 
 func (p *getPreimageSize) RequiredGas(input []byte) uint64 {
@@ -231,7 +231,7 @@ func (p *getPreimageSize) Run(API api.API, input []byte) ([]byte, error) {
 }
 
 type getPreimage struct {
-	blankRegistryMethod
+	blankPreimageRegistryMethod
 }
 
 func (p *getPreimage) RequiredGas(input []byte) uint64 {

--- a/concrete/precompiles/preimage_registry_test.go
+++ b/concrete/precompiles/preimage_registry_test.go
@@ -22,13 +22,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/concrete/api"
 	api_test "github.com/ethereum/go-ethereum/concrete/api/test"
-	"github.com/ethereum/go-ethereum/concrete/lib"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
 
 type preimageRegistryPCWrapper struct {
-	*lib.PrecompileWithABI
+	PreimageRegistryPrecompile
 	API api.API
 }
 
@@ -105,10 +104,9 @@ func TestPreimageRegistry(t *testing.T) {
 	var (
 		r        = require.New(t)
 		address  = api.PreimageRegistryAddress
-		pc       = precompiles[address].(*lib.PrecompileWithABI)
 		evm      = api_test.NewMockEVM(api_test.NewMockStateDB())
 		API      = api.New(evm, address)
-		wpc      = &preimageRegistryPCWrapper{PrecompileWithABI: pc, API: API}
+		wpc      = &preimageRegistryPCWrapper{*PreimageRegistry, API}
 		preimage = []byte("test.data")
 		hash     = crypto.Keccak256Hash(preimage)
 	)
@@ -148,10 +146,9 @@ func TestBigPreimageRegistry(t *testing.T) {
 		radix    = 16
 		leafSize = 64
 		address  = api.BigPreimageRegistryAddress
-		pc       = precompiles[address].(*lib.PrecompileWithABI)
 		evm      = api_test.NewMockEVM(api_test.NewMockStateDB())
 		API      = api.New(evm, address)
-		wpc      = &preimageRegistryPCWrapper{PrecompileWithABI: pc, API: API}
+		wpc      = &preimageRegistryPCWrapper{*BigPreimageRegistry, API}
 		preimage = []byte("test.data")
 	)
 


### PR DESCRIPTION
Calls to non-existent methods or sub-precompiles or with malformed inputs will have a non-0 (10 gas) cost.