### PR TITLE
feat: set registry gas costs

### DIFF
--- a/concrete/precompiles/precompile_registry.go
+++ b/concrete/precompiles/precompile_registry.go
@@ -39,11 +39,11 @@ var PrecompileRegistryMetadata = PrecompileMetadata{
 }
 
 var (
-	GetFrameworkGas            = uint64(10)
-	GetPrecompileGas           = uint64(10)
-	GetPrecompileByNameGas     = uint64(10)
-	GetPrecompiledAddressesGas = uint64(10)
-	GetPrecompilesGas          = uint64(10)
+	GetFrameworkGas                         = uint64(15)
+	GetPrecompileGas                        = uint64(50)
+	GetPrecompileByNameGas                  = uint64(5)
+	GetPrecompiledAddressesPerPrecompileGas = uint64(5)
+	GetPrecompilesPrePrecompileGas          = uint64(50)
 )
 
 func init() {
@@ -128,7 +128,7 @@ type getPrecompiledAddresses struct {
 }
 
 func (p *getPrecompiledAddresses) RequiredGas(input []byte) uint64 {
-	return GetPrecompiledAddressesGas
+	return GetPrecompiledAddressesPerPrecompileGas * uint64(len(precompiledAddresses))
 }
 
 func (p *getPrecompiledAddresses) Run(API api.API, input []byte) ([]byte, error) {
@@ -142,7 +142,7 @@ type getPrecompiles struct {
 }
 
 func (p *getPrecompiles) RequiredGas(input []byte) uint64 {
-	return GetPrecompilesGas
+	return GetPrecompilesPrePrecompileGas * uint64(len(precompileMetadata))
 }
 
 func (p *getPrecompiles) Run(concrete api.API, input []byte) ([]byte, error) {

--- a/concrete/precompiles/preimage_registry.go
+++ b/concrete/precompiles/preimage_registry.go
@@ -56,21 +56,21 @@ var (
 	}
 	DefaultPreimageRegistryGasTable = PreimageRegistryGasTable{
 		FailGas:               10,
-		AddPreimageGas:        10,
-		AddPreimagePerByteGas: 10,
-		HasPreimageGas:        10,
-		GetPreimageSizeGas:    10,
-		GetPreimageGas:        10,
-		GetPreimagePerByteGas: 10,
+		AddPreimageGas:        20000,
+		AddPreimagePerByteGas: 100,
+		HasPreimageGas:        1000,
+		GetPreimageSizeGas:    1000,
+		GetPreimageGas:        1000,
+		GetPreimagePerByteGas: 50,
 	}
 	DefaultBigPreimageRegistryGasTable = PreimageRegistryGasTable{
 		FailGas:               10,
-		AddPreimageGas:        10,
-		AddPreimagePerByteGas: 10,
-		HasPreimageGas:        10,
-		GetPreimageSizeGas:    10,
-		GetPreimageGas:        10,
-		GetPreimagePerByteGas: 10,
+		AddPreimageGas:        20000,
+		AddPreimagePerByteGas: 250,
+		HasPreimageGas:        1000,
+		GetPreimageSizeGas:    1000,
+		GetPreimageGas:        1000,
+		GetPreimagePerByteGas: 125,
 	}
 )
 


### PR DESCRIPTION
This PR sets the gas costs associated with interacting with the built-in registries to a quick ballpark estimate of their fair value. A more precise calculation should be done in the future.