### PR TITLE
Feat/cli test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = tests/evm-benchmarks
 	url = https://github.com/ipsilon/evm-benchmarks
 	shallow = true
+[submodule "concrete/testing/testdata/lib/forge-std"]
+	path = concrete/testing/testdata/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/concrete/cmd/test.go
+++ b/concrete/cmd/test.go
@@ -18,5 +18,5 @@ package main
 import "github.com/ethereum/go-ethereum/concrete/testing"
 
 func main() {
-	testing.Test()
+	testing.TestCmd()
 }

--- a/concrete/cmd/test.go
+++ b/concrete/cmd/test.go
@@ -13,34 +13,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the concrete library. If not, see <http://www.gnu.org/licenses/>.
 
-package testing
+package main
 
-import (
-	_ "embed"
-	"testing"
-)
+import "github.com/ethereum/go-ethereum/concrete/testing"
 
-//go:embed testdata/out/Test.sol/Test.json
-var testContractJsonBytes []byte
-
-func TestRunTestContract(t *testing.T) {
-	bytecode, ABI, _, err := extractTestData(testContractJsonBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	passed, failed := runTestContract(bytecode, ABI)
-	if failed > 0 {
-		t.Errorf("failed tests: %v", failed)
-	}
-	if passed == 0 {
-		t.Error("no tests passed")
-	}
+func main() {
+	testing.Test()
 }
-
-// func TestRunTests(t *testing.T) {
-// 	testPaths, err := getTestPaths("./testdata/src", "testdata/out")
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	runTestPaths(testPaths)
-// }

--- a/concrete/testing/main.go
+++ b/concrete/testing/main.go
@@ -41,7 +41,7 @@ func runTestMethod(bytecode []byte, method abi.Method, shouldFail bool) (uint64,
 		senderAddress   = crypto.PubkeyToAddress(key.PublicKey)
 		contractAddress = common.HexToAddress("0x0000000000000000000000000000000000c0ffee")
 		gspec           = &core.Genesis{
-			GasLimit: 15e6,
+			GasLimit: 2e7,
 			Config:   params.TestChainConfig,
 			Alloc: core.GenesisAlloc{
 				senderAddress:   {Balance: big.NewInt(1e18)},

--- a/concrete/testing/main.go
+++ b/concrete/testing/main.go
@@ -48,7 +48,7 @@ func runTestMethod(bytecode []byte, method abi.Method, shouldFail bool) (uint64,
 			},
 		}
 		signer   = types.LatestSigner(gspec.Config)
-		gasLimit = uint64(1e6)
+		gasLimit = uint64(1e7)
 		setupId  = crypto.Keccak256([]byte("setUp()"))[:4]
 	)
 

--- a/concrete/testing/main.go
+++ b/concrete/testing/main.go
@@ -172,7 +172,7 @@ func getTestPaths(testDir, outDir string) ([]string, error) {
 	return paths, nil
 }
 
-func runTestPaths(contractJsonPaths []string) {
+func runTestPaths(contractJsonPaths []string) (int, int) {
 	var totalPassed, totalFailed int
 	startTime := time.Now()
 
@@ -200,6 +200,8 @@ func runTestPaths(contractJsonPaths []string) {
 	}
 
 	fmt.Printf("\nTest result: %s. %d passed; %d failed; finished in %.2fms\n", result, totalPassed, totalFailed, timeMs)
+
+	return totalPassed, totalFailed
 }
 
 type TestConfig struct {
@@ -208,7 +210,7 @@ type TestConfig struct {
 	OutDir   string
 }
 
-func Test(config TestConfig) {
+func Test(config TestConfig) (int, int) {
 	// Get test paths
 	var testPaths []string
 
@@ -216,7 +218,7 @@ func Test(config TestConfig) {
 		parts := strings.SplitN(config.Contract, ":", 2)
 		if len(parts) != 2 {
 			fmt.Printf("Invalid contract: %s. Must follow format Path:Contract\n", config.Contract)
-			return
+			os.Exit(1)
 		}
 		_, fileName := filepath.Split(parts[0])
 		contractName := parts[1]
@@ -227,12 +229,12 @@ func Test(config TestConfig) {
 		testPaths, err = getTestPaths(config.TestDir, config.OutDir)
 		if err != nil {
 			fmt.Printf("Error getting test paths: %s\n", err)
-			return
+			os.Exit(1)
 		}
 	}
 
 	// Run tests
-	runTestPaths(testPaths)
+	return runTestPaths(testPaths)
 }
 
 func TestCmd() {

--- a/concrete/testing/main.go
+++ b/concrete/testing/main.go
@@ -1,0 +1,189 @@
+// Copyright 2023 The concrete-geth Authors
+//
+// The concrete-geth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The concrete library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the concrete library. If not, see <http://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func runTest(bytecode []byte, method abi.Method, shouldFail bool) (uint64, error) {
+	var (
+		key, _          = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		senderAddress   = crypto.PubkeyToAddress(key.PublicKey)
+		contractAddress = common.HexToAddress("0x0000000000000000000000000000000000c0ffee")
+		gspec           = &core.Genesis{
+			Config: params.TestChainConfig,
+			Alloc: core.GenesisAlloc{
+				senderAddress:   {Balance: big.NewInt(1e18)},
+				contractAddress: {Balance: common.Big0, Code: bytecode},
+			},
+		}
+		signer   = types.LatestSigner(gspec.Config)
+		gasLimit = uint64(1e6)
+		setupId  = crypto.Keccak256([]byte("setUp()"))[:4]
+	)
+
+	_, _, receipts := core.GenerateChainWithGenesis(gspec, ethash.NewFaker(), 1, func(ii int, block *core.BlockGen) {
+		for _, id := range [][]byte{setupId, method.ID} {
+			tx := types.NewTransaction(block.TxNonce(senderAddress), contractAddress, common.Big0, gasLimit, block.BaseFee(), id)
+			signed, err := types.SignTx(tx, signer, key)
+			if err != nil {
+				panic(err)
+			}
+			block.AddTx(signed)
+		}
+	})
+
+	if len(receipts[0]) != 2 {
+		return 0, fmt.Errorf("expected 2 receipts, got %d", len(receipts))
+	}
+	setupReceipt := receipts[0][0]
+	testReceipt := receipts[0][1]
+	if setupReceipt.Status != types.ReceiptStatusSuccessful {
+		return 0, fmt.Errorf("setup failed")
+	}
+	if (testReceipt.Status == types.ReceiptStatusSuccessful) == shouldFail {
+		return 0, fmt.Errorf("test failed")
+	}
+
+	return testReceipt.GasUsed, nil
+}
+
+func runTests(bytecode []byte, ABI abi.ABI) (int, int) {
+	passed := 0
+	failed := 0
+	for _, method := range ABI.Methods {
+		if !strings.HasPrefix(method.Name, "test") {
+			continue
+		}
+		shouldFail := strings.HasPrefix(method.Name, "testFail")
+		gas, err := runTest(bytecode, method, shouldFail)
+		if err == nil {
+			passed++
+			fmt.Printf("[PASS] %s() (gas: %d)\n", method.Name, gas)
+		} else {
+			failed++
+			fmt.Printf("[FAIL] %s() (gas: %d): %s\n", method.Name, gas, err)
+		}
+	}
+	return passed, failed
+}
+
+func extractTestData(contractJsonBytes []byte) ([]byte, abi.ABI, string, error) {
+	var jsonData struct {
+		ABI              abi.ABI `json:"abi"`
+		DeployedBytecode struct {
+			Object string `json:"object"`
+		} `json:"deployedBytecode"`
+		Ast struct {
+			AbsolutePath string `json:"absolutePath"`
+		} `json:"ast"`
+	}
+	err := json.Unmarshal(contractJsonBytes, &jsonData)
+	if err != nil {
+		return nil, abi.ABI{}, "", err
+	}
+	bytecode := common.FromHex(jsonData.DeployedBytecode.Object)
+	return bytecode, jsonData.ABI, jsonData.Ast.AbsolutePath, nil
+}
+
+func getFileNames(dir string, ext string) ([]string, error) {
+	var fileNames []string
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fileNames, err
+	}
+
+	for _, file := range files {
+		filePath := filepath.Join(dir, file.Name())
+		if file.IsDir() {
+			subDirFileNames, err := getFileNames(filePath, ext)
+			if err != nil {
+				return fileNames, err
+			}
+			fileNames = append(fileNames, subDirFileNames...)
+		} else if ext == "" || filepath.Ext(file.Name()) == ext {
+			fileNames = append(fileNames, file.Name())
+		}
+	}
+
+	return fileNames, nil
+}
+
+func RunTests(testDir, outDir string) {
+	var totalPassed, totalFailed int
+	seenFiles := make(map[string]struct{})
+	startTime := time.Now()
+
+	testFileNames, err := getFileNames(testDir, ".sol")
+	if err != nil {
+		fmt.Println("Error finding tests:", err)
+		return
+	}
+	for _, fileName := range testFileNames {
+		if _, ok := seenFiles[fileName]; ok {
+			continue
+		}
+		seenFiles[fileName] = struct{}{}
+		contractNames, err := getFileNames(filepath.Join(outDir, fileName), ".json")
+		if err != nil {
+			fmt.Println("Error finding contract data:", err)
+			return
+		}
+		for _, contractName := range contractNames {
+			data, err := ioutil.ReadFile(filepath.Join(outDir, fileName, contractName))
+			if err != nil {
+				fmt.Println("Error reading contract data:", err)
+				return
+			}
+			bytecode, ABI, path, err := extractTestData(data)
+			if err != nil {
+				fmt.Println("Error extracting contract data:", err)
+				return
+			}
+			fmt.Printf("\nRunning tests for %s\n", path)
+			passed, failed := runTests(bytecode, ABI)
+			totalPassed += passed
+			totalFailed += failed
+		}
+	}
+
+	timeMs := float64(time.Since(startTime).Microseconds()) / 1000
+
+	var result string
+	if totalFailed == 0 {
+		result = "ok"
+	} else {
+		result = "FAILED"
+	}
+
+	fmt.Printf("\nTest result: %s. %d passed; %d failed; finished in %.2fms\n", result, totalPassed, totalFailed, timeMs)
+}

--- a/concrete/testing/main.go
+++ b/concrete/testing/main.go
@@ -41,7 +41,8 @@ func runTestMethod(bytecode []byte, method abi.Method, shouldFail bool) (uint64,
 		senderAddress   = crypto.PubkeyToAddress(key.PublicKey)
 		contractAddress = common.HexToAddress("0x0000000000000000000000000000000000c0ffee")
 		gspec           = &core.Genesis{
-			Config: params.TestChainConfig,
+			GasLimit: 15e6,
+			Config:   params.TestChainConfig,
 			Alloc: core.GenesisAlloc{
 				senderAddress:   {Balance: big.NewInt(1e18)},
 				contractAddress: {Balance: common.Big0, Code: bytecode},

--- a/concrete/testing/main_test.go
+++ b/concrete/testing/main_test.go
@@ -42,5 +42,8 @@ func TestRunTestContract(t *testing.T) {
 // 	if err != nil {
 // 		t.Fatal(err)
 // 	}
+// 	if len(testPaths) == 0 {
+// 		t.Fatal("no test paths found")
+// 	}
 // 	runTestPaths(testPaths)
 // }

--- a/concrete/testing/main_test.go
+++ b/concrete/testing/main_test.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The concrete-geth Authors
+//
+// The concrete-geth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The concrete library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the concrete library. If not, see <http://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	_ "embed"
+	"testing"
+)
+
+//go:embed testdata/out/Test.sol/Test.json
+var testContractJsonBytes []byte
+
+func TestRunTestContract(t *testing.T) {
+	bytecode, ABI, _, err := extractTestData(testContractJsonBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passed, failed := runTests(bytecode, ABI)
+	if failed > 0 {
+		t.Errorf("failed tests: %v", failed)
+	}
+	if passed == 0 {
+		t.Error("no tests passed")
+	}
+}
+
+// func TestRunTests(t *testing.T) {
+// 	RunTests("./testdata/src", "testdata/out")
+// }

--- a/concrete/testing/testdata/.gitignore
+++ b/concrete/testing/testdata/.gitignore
@@ -1,0 +1,14 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/concrete/testing/testdata/foundry.toml
+++ b/concrete/testing/testdata/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/concrete/testing/testdata/src/Test.sol
+++ b/concrete/testing/testdata/src/Test.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+/*
+This contract tests two things:
+- The setup function is called before each test function in a clean environment
+- `^test` functions are expected to succeed and `^testFail` functions are expected to fail
+*/
+
+contract Test {
+    uint256 public value;
+
+    function setUp() external {
+        if (value != 0) {
+            revert("value is not 0");
+        }
+        value = 1;
+        return;
+    }
+
+    function testSuccess() external {
+        if (value != 1) {
+            revert("value is not 1");
+        }
+        value = 2;
+        return;
+    }
+
+    function testFailure() external {
+        if (value != 1) {
+            return;
+        }
+        value = 2;
+        revert("test failure");
+    }
+}

--- a/concrete/testing/testdata/src/TestFail.sol
+++ b/concrete/testing/testdata/src/TestFail.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+/*
+This contract tests two things:
+- The setup function is called before each test function in a clean environment
+- `^test` functions are expected to succeed and `^testFail` functions are expected to fail
+*/
+
+contract TestFail {
+    function setUp() external {}
+
+    function testSuccess() external pure {
+        revert();
+    }
+
+    function testFailure() external pure {
+        return;
+    }
+}


### PR DESCRIPTION
Add a basic tool to run End-to-End tests written in Solidity.

Every contract in the designated testing directory will be treated as a test. The `setUp`, `test`, and `testFail` keywords are supported and have the same functionality as they do in [foundry's forge](https://github.com/foundry-rs/foundry).

```solidity
contract Test {
    // setUp: An function invoked before each test case is run.
    // It is not optional but it should be.
    function setUp() external {
        return;
    }

    // test: Functions prefixed with test are run as a test case.
    // This will pass.
    function testSuccess() external {
        return;
    }

    // testFail: The inverse of the test prefix - if the function does not revert, the test fails.
    // This will pass.
    function testFailure() external {
        revert();
    }
}
```