### PR TITLE
therealbytes/copy

### DIFF
--- a/concrete/api/methods_go.go
+++ b/concrete/api/methods_go.go
@@ -37,22 +37,19 @@ import (
 func newEnvironmentMethods() JumpTable {
 	tbl := JumpTable{
 		EnableGasMetering_OpCode: {
-			execute:     opEnableGasMetering,
-			constantGas: 0,
-			trusted:     true,
-			static:      true,
+			execute: opEnableGasMetering,
+			trusted: true,
+			static:  true,
 		},
 		Debug_OpCode: {
-			execute:     opDebug,
-			constantGas: 0,
-			trusted:     true,
-			static:      true,
+			execute: opDebug,
+			trusted: true,
+			static:  true,
 		},
 		TimeNow_OpCode: {
-			execute:     opTimeNow,
-			constantGas: 0,
-			trusted:     true,
-			static:      true,
+			execute: opTimeNow,
+			trusted: true,
+			static:  true,
 		},
 		Keccak256_OpCode: {
 			execute:     opKeccak256,
@@ -621,7 +618,9 @@ func opGetCallData(env *Env, args [][]byte) ([][]byte, error) {
 		return nil, ErrNoData
 	}
 	data := env.call.CallData()
-	return [][]byte{data}, nil
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+	return [][]byte{dataCopy}, nil
 }
 
 func opGetCallDataSize(env *Env, args [][]byte) ([][]byte, error) {
@@ -745,10 +744,12 @@ func opLog(env *Env, args [][]byte) ([][]byte, error) {
 		topics[i] = common.BytesToHash(arg)
 	}
 	data := args[len(args)-1]
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
 	env.statedb.AddLog(&types.Log{
 		Address:     env.address,
 		Topics:      topics,
-		Data:        data,
+		Data:        dataCopy,
 		BlockNumber: env.block.BlockNumber(),
 	})
 	return nil, nil
@@ -824,7 +825,9 @@ func gasGetExternalCode(env *Env, args [][]byte) (uint64, error) {
 func opGetExternalCode(env *Env, args [][]byte) ([][]byte, error) {
 	address := common.BytesToAddress(args[0])
 	code := env.statedb.GetCode(address)
-	return [][]byte{code}, nil
+	codeCopy := make([]byte, len(code))
+	copy(codeCopy, code)
+	return [][]byte{codeCopy}, nil
 }
 
 func gasGetExternalCodeSize(env *Env, args [][]byte) (uint64, error) {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -270,9 +270,10 @@ func (s *StateDB) addEphemeralPreimage(hash common.Hash, preimage []byte) {
 }
 
 func (s *StateDB) getEphemeralPreimage(hash common.Hash) []byte {
-	preimage := make([]byte, len(s.ephemeralPreimages[hash]))
-	copy(preimage, s.ephemeralPreimages[hash])
-	return preimage
+	preimage := s.ephemeralPreimages[hash]
+	pi := make([]byte, len(preimage))
+	copy(pi, preimage)
+	return pi
 }
 
 func (s *StateDB) AddEphemeralPreimage(hash common.Hash, preimage []byte) {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -270,7 +270,9 @@ func (s *StateDB) addEphemeralPreimage(hash common.Hash, preimage []byte) {
 }
 
 func (s *StateDB) getEphemeralPreimage(hash common.Hash) []byte {
-	return s.ephemeralPreimages[hash]
+	preimage := make([]byte, len(s.ephemeralPreimages[hash]))
+	copy(preimage, s.ephemeralPreimages[hash])
+	return preimage
 }
 
 func (s *StateDB) AddEphemeralPreimage(hash common.Hash, preimage []byte) {
@@ -315,30 +317,33 @@ func (s *StateDB) AddPersistentPreimage(hash common.Hash, preimage []byte) {
 	if _, ok := s.persistentPreimagesSize[hash]; ok {
 		// The size was read from the DB, but the preimage was not.
 		// The preimage is already committed, so it can be added as if it was read.
-		s.persistentPreimagesRead[hash] = struct{}{}
-		s.persistentPreimages[hash] = preimage
 		delete(s.persistentPreimagesSize, hash)
+		s.persistentPreimagesRead[hash] = struct{}{}
+	} else {
+		s.journal.append(persistentPreimageChange{hash: hash})
+		s.persistentPreimagesDirty[hash] = struct{}{}
 	}
-	s.journal.append(persistentPreimageChange{hash: hash})
-	s.persistentPreimagesDirty[hash] = struct{}{}
 	pi := make([]byte, len(preimage))
 	copy(pi, preimage)
 	s.persistentPreimages[hash] = pi
 }
 
 func (s *StateDB) GetPersistentPreimage(hash common.Hash) []byte {
+	var preimage []byte
 	if s.persistentPreimageCached(hash) {
-		preimage := s.persistentPreimages[hash]
-		return preimage
+		preimage = s.persistentPreimages[hash]
+	} else {
+		preimage, err := s.db.ConcretePreimage(hash)
+		if err != nil {
+			s.setError(fmt.Errorf("can't load persistent preimage %x: %v", hash, err))
+			return []byte{}
+		}
+		s.persistentPreimagesRead[hash] = struct{}{}
+		s.persistentPreimages[hash] = preimage
 	}
-	preimage, err := s.db.ConcretePreimage(hash)
-	if err != nil {
-		s.setError(fmt.Errorf("can't load persistent preimage %x: %v", hash, err))
-		return []byte{}
-	}
-	s.persistentPreimagesRead[hash] = struct{}{}
-	s.persistentPreimages[hash] = preimage
-	return preimage
+	pi := make([]byte, len(preimage))
+	copy(pi, preimage)
+	return pi
 }
 
 func (s *StateDB) GetPersistentPreimageSize(hash common.Hash) int {
@@ -358,7 +363,8 @@ func (s *StateDB) GetPersistentPreimageSize(hash common.Hash) int {
 		// All preimages marked as cached are in the map but not all preimages
 		// in the map are marked as cached as the transaction that added a
 		// dirty preimage may have been reverted.
-		// The preimage is in the DB, so it can be added as if it was read.
+		// The preimage is in the DB, otherwise it would not be possible to get the
+		// size without it being cached, so it can be added as if it was read.
 		s.persistentPreimagesRead[hash] = struct{}{}
 		return size
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -657,7 +657,7 @@ func (b *concreteCallContext) TxOrigin() common.Address {
 }
 
 func (b *concreteCallContext) CallData() []byte {
-	return b.contract.Input // TODO
+	return b.contract.Input
 }
 
 func (b *concreteCallContext) CallDataSize() int {


### PR DESCRIPTION
- Use copies of reference types in Environment and StateDB for variables that might be modified by the end developer later on