### PR TITLE
therealbytes/dev

### DIFF
--- a/concrete/cmd/concrete/main.go
+++ b/concrete/cmd/concrete/main.go
@@ -28,10 +28,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func exit(msg string) {
+	fmt.Println("--------------------------------")
+	fmt.Println("[ERROR]")
+	fmt.Println(msg)
+	os.Exit(1)
+}
+
 func checkErr(err error) {
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		exit(err.Error())
 	}
 }
 
@@ -91,8 +97,7 @@ func main() {
 	rootCmd.AddCommand(cmdDatamod)
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		exit(err.Error())
 	}
 }
 
@@ -109,19 +114,16 @@ func runSolgen(cmd *cobra.Command, args []string) {
 	checkErr(err)
 
 	if abiPath == "" {
-		fmt.Println("Missing ABI file path (--abi)")
-		os.Exit(1)
+		exit("ABI file path (--abi) must be provided")
 	}
 	if outPath == "" {
-		fmt.Println("Missing output file path (--out))")
-		os.Exit(1)
+		exit("Output file path (--out) must be provided")
 	}
 
 	if address == "" {
-		fmt.Println("Missing precompile address (--address)")
+		exit("Precompile address (--address) must be provided")
 	} else if !common.IsHexAddress(common.HexToAddress(address).Hex()) {
-		fmt.Println("Invalid address:", address)
-		os.Exit(1)
+		exit("Precompile address (--address) must be a valid hex address")
 	} else {
 		address = common.HexToAddress(address).Hex()
 	}
@@ -132,8 +134,7 @@ func runSolgen(cmd *cobra.Command, args []string) {
 	checkErr(err)
 
 	if abiIsDir {
-		fmt.Println("ABI path must be a file")
-		os.Exit(1)
+		exit("ABI path must be a file")
 	}
 
 	if name == "" {
@@ -176,15 +177,13 @@ func runDatamod(cmd *cobra.Command, args []string) {
 	jsonIsDir, err := isDir(jsonPath)
 	checkErr(err)
 	if jsonIsDir {
-		fmt.Println("JSON path must be a file")
-		os.Exit(1)
+		exit("JSON path must be a file")
 	}
 
 	outIsDir, err := isDir(outPath)
 	checkErr(err)
 	if !outIsDir {
-		fmt.Println("Output path must be a directory")
-		os.Exit(1)
+		exit("Output path must be a directory")
 	}
 
 	config := datamod.Config{
@@ -198,5 +197,5 @@ func runDatamod(cmd *cobra.Command, args []string) {
 	err = datamod.GenerateDataModel(config)
 	checkErr(err)
 
-	fmt.Println("Data model wrappers generated successfully.")
+	fmt.Println("Data model wrappers generated successfully.\nFiles written to:", outPath)
 }

--- a/concrete/codegen/datamod/datamod.go
+++ b/concrete/codegen/datamod/datamod.go
@@ -51,13 +51,12 @@ func upperFirstLetter(str string) string {
 	return string(runes)
 }
 
-func contains(tableNames []string, tableName string) bool {
-	for _, _tableName := range tableNames {
-		if tableName == _tableName {
-			return true
-		}
-	}
-	return false
+func formatTableName(tableName string) string {
+	return upperFirstLetter(tableName)
+}
+
+func formatRowName(tableName string) string {
+	return upperFirstLetter(tableName) + "Row"
 }
 
 func isValidName(name string) bool {
@@ -163,8 +162,9 @@ func unmarshalTableSchemas(jsonContent []byte) ([]TableSchema, error) {
 				return []TableSchema{}, err
 			}
 			if fieldSchema.Type.Type == TableType {
-				if !contains(jsonSchemas.Keys(), fieldSchema.Type.Name) {
-					return []TableSchema{}, fmt.Errorf("table name '%s' in '%s' does not match any tables", fieldSchema.Type.Name, tableName)
+				_, ok := jsonSchemas.Get(fieldSchema.Type.Name)
+				if !ok {
+					return []TableSchema{}, fmt.Errorf("table '%s' does not exist", fieldSchema.Type.Name)
 				}
 			}
 			tableSchema.Values = append(tableSchema.Values, fieldSchema)
@@ -203,8 +203,8 @@ func GenerateDataModel(config Config) error {
 	}
 
 	for _, schema := range schemas {
-		tableName := schema.Name
-		rowName := schema.Name + "Row"
+		tableName := formatTableName(schema.Name)
+		rowName := formatRowName(schema.Name)
 
 		_sizes := make([]string, len(schema.Values))
 		for i, field := range schema.Values {

--- a/concrete/codegen/datamod/datamod.go
+++ b/concrete/codegen/datamod/datamod.go
@@ -87,7 +87,7 @@ func newFieldSchema(name string, index int, typeStr string) (FieldSchema, error)
 	}
 	fieldType, err := nameToFieldType(typeStr)
 	if err != nil {
-		return FieldSchema{}, err
+		return FieldSchema{}, fmt.Errorf("invalid type '%s' for field '%s': %w", typeStr, name, err)
 	}
 	return FieldSchema{
 		Name:  lowerFirstLetter(name),
@@ -164,7 +164,7 @@ func unmarshalTableSchemas(jsonContent []byte) ([]TableSchema, error) {
 			}
 			if fieldSchema.Type.Type == TableType {
 				if !contains(jsonSchemas.Keys(), fieldSchema.Type.Name) {
-					return []TableSchema{}, fmt.Errorf("table name '%s' table in '%s' does not match any tables", fieldSchema.Type.Name, tableName)
+					return []TableSchema{}, fmt.Errorf("table name '%s' in '%s' does not match any tables", fieldSchema.Type.Name, tableName)
 				}
 			}
 			tableSchema.Values = append(tableSchema.Values, fieldSchema)

--- a/concrete/codegen/datamod/field.go
+++ b/concrete/codegen/datamod/field.go
@@ -41,8 +41,6 @@ type FieldType struct {
 }
 
 func nameToFieldType(name string) (FieldType, error) {
-	name = strings.ToLower(name)
-
 	switch name {
 	case "address":
 		return FieldType{
@@ -169,7 +167,7 @@ func nameToFieldType(name string) (FieldType, error) {
 		return FieldType{
 			Name:   tableName,
 			Size:   32,
-			GoType: upperFirstLetter(tableName),
+			GoType: formatTableName(tableName),
 			Type:   TableType,
 		}, nil
 	}

--- a/concrete/codegen/datamod/field.go
+++ b/concrete/codegen/datamod/field.go
@@ -27,6 +27,10 @@ const (
 	TableType
 )
 
+const (
+	AllowTableTypes = false
+)
+
 type FieldType struct {
 	Name       string
 	Type       int
@@ -155,6 +159,9 @@ func nameToFieldType(name string) (FieldType, error) {
 	}
 
 	if strings.HasPrefix(name, "table ") {
+		if !AllowTableTypes {
+			return FieldType{}, fmt.Errorf("table types are not allowed")
+		}
 		tableName := strings.TrimPrefix(name, "table ")
 		if !isValidName(tableName) {
 			return FieldType{}, fmt.Errorf("invalid table name %s", tableName)

--- a/concrete/codegen/datamod/field_type.go
+++ b/concrete/codegen/datamod/field_type.go
@@ -27,10 +27,6 @@ const (
 	TableType
 )
 
-const (
-	AllowTableTypes = false
-)
-
 type FieldType struct {
 	Name       string
 	Type       int
@@ -157,9 +153,6 @@ func nameToFieldType(name string) (FieldType, error) {
 	}
 
 	if strings.HasPrefix(name, "table ") {
-		if !AllowTableTypes {
-			return FieldType{}, fmt.Errorf("table types are not allowed")
-		}
 		tableName := strings.TrimPrefix(name, "table ")
 		if !isValidName(tableName) {
 			return FieldType{}, fmt.Errorf("invalid table name %s", tableName)

--- a/concrete/codegen/datamod/utils.go
+++ b/concrete/codegen/datamod/utils.go
@@ -1,0 +1,56 @@
+// Copyright 2023 The concrete-geth Authors
+//
+// The concrete-geth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The concrete library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the concrete library. If not, see <http://www.gnu.org/licenses/>.
+
+package datamod
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+func lowerFirstLetter(str string) string {
+	if len(str) == 0 {
+		return ""
+	}
+	runes := []rune(str)
+	runes[0] = unicode.ToLower(runes[0])
+	return string(runes)
+}
+
+func upperFirstLetter(str string) string {
+	if len(str) == 0 {
+		return ""
+	}
+	runes := []rune(str)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
+}
+
+func formatTableName(tableName string) string {
+	return upperFirstLetter(tableName)
+}
+
+func formatRowName(tableName string) string {
+	return upperFirstLetter(tableName) + "Row"
+}
+
+func isValidName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	re := regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+	return re.MatchString(name) && len(strings.TrimSpace(name)) == len(name)
+}

--- a/concrete/fixtures/datamod/kkv.go
+++ b/concrete/fixtures/datamod/kkv.go
@@ -26,9 +26,9 @@ type KkvRow struct {
 	lib.DatastoreStruct
 }
 
-func NewKkvRow(store lib.DatastoreSlot) *KkvRow {
+func NewKkvRow(dsSlot lib.DatastoreSlot) *KkvRow {
 	sizes := []int{32}
-	return &KkvRow{*lib.NewDatastoreStruct(store, sizes)}
+	return &KkvRow{*lib.NewDatastoreStruct(dsSlot, sizes)}
 }
 
 func (v *KkvRow) Get() (
@@ -54,24 +54,25 @@ func (v *KkvRow) SetValue(value common.Hash) {
 }
 
 type Kkv struct {
-	store lib.DatastoreSlot
+	dsSlot lib.DatastoreSlot
 }
 
 func NewKkv(ds lib.Datastore) *Kkv {
-	return &Kkv{ds.Get(KkvDefaultKey)}
+	dsSlot := ds.Get(KkvDefaultKey)
+	return &Kkv{dsSlot}
 }
 
-func NewKkvWithKey(ds lib.Datastore, key []byte) *Kkv {
-	return &Kkv{ds.Get(key)}
+func NewKkvFromSlot(dsSlot lib.DatastoreSlot) *Kkv {
+	return &Kkv{dsSlot}
 }
 
 func (m *Kkv) Get(
 	key1 common.Hash,
 	key2 common.Hash,
 ) *KkvRow {
-	store := m.store.Mapping().GetNested(
+	dsSlot := m.dsSlot.Mapping().GetNested(
 		codec.EncodeHash(32, key1),
 		codec.EncodeHash(32, key2),
 	)
-	return NewKkvRow(store)
+	return NewKkvRow(dsSlot)
 }


### PR DESCRIPTION
- Fix datamod syntax issues when using keyless tables as value types
- Reorg datamod dir
- Add `AllowTableTypes = false` -- still looking for a reasonable use case where nested tables are not an anti-pattern
- Better CLI error logging