### PR TITLE
feat: handle and test wasm env error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,10 @@ concrete-wasm:
 	tinygo build -opt=2 -o $(E2E_DIR)/build/blank.wasm -target=wasi $(TINYGO_PCS_DIR)/blank/blank.go
 	tinygo build -opt=2 -o $(E2E_DIR)/build/add.wasm -target=wasi $(TINYGO_PCS_DIR)/add/add.go
 	tinygo build -opt=2 -o $(E2E_DIR)/build/kkv.wasm -target=wasi $(TINYGO_PCS_DIR)/kkv/kkv.go
+	tinygo build -opt=2 -o $(E2E_DIR)/build/gas.wasm -target=wasi $(TINYGO_PCS_DIR)/gas/gas.go
 	mkdir -p $(WASM_TESTDATA_DIR)
 	cp $(E2E_DIR)/build/blank.wasm $(WASM_TESTDATA_DIR)/blank.wasm
+	cp $(E2E_DIR)/build/gas.wasm $(WASM_TESTDATA_DIR)/gas.wasm
 
 concrete-solidity:
 	cd ./concrete/testtool/testdata && forge build

--- a/concrete/e2e/fixtures.go
+++ b/concrete/e2e/fixtures.go
@@ -102,3 +102,17 @@ func (a *KeyKeyValuePrecompile) Run(env api.Environment, input []byte) ([]byte, 
 	}
 	return nil, ErrMethodNotFound
 }
+
+var _ concrete.Precompile = &KeyKeyValuePrecompile{}
+
+type GasPrecompile struct {
+	lib.BlankPrecompile
+}
+
+func (a *GasPrecompile) Run(env api.Environment, input []byte) ([]byte, error) {
+	gas := uint64(input[0])
+	env.UseGas(gas)
+	return []byte{1}, nil
+}
+
+var _ concrete.Precompile = &GasPrecompile{}

--- a/concrete/wasm/memory/memory.go
+++ b/concrete/wasm/memory/memory.go
@@ -157,6 +157,9 @@ func PutReturnWithError(memory Memory, retValues [][]byte, retErr error) MemPoin
 
 func GetReturnWithError(memory Memory, retPointer MemPointer, free bool) ([][]byte, error) {
 	retValues := GetReturn(memory, retPointer, free)
+	if len(retValues) == 0 {
+		return nil, nil
+	}
 	err := utils.DecodeError(retValues[len(retValues)-1])
 	return retValues[:len(retValues)-1], err
 }

--- a/concrete/wasm/wasm_test.go
+++ b/concrete/wasm/wasm_test.go
@@ -1,0 +1,55 @@
+// Copyright 2023 The concrete-geth Authors
+//
+// The concrete-geth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The concrete library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the concrete library. If not, see <http://www.gnu.org/licenses/>.
+
+package wasm
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/concrete"
+	"github.com/ethereum/go-ethereum/concrete/api"
+	"github.com/ethereum/go-ethereum/concrete/mock"
+)
+
+//go:embed testdata/gas.wasm
+var errCode []byte
+
+func TestWasmEnvErr(t *testing.T) {
+	input := []byte{1}
+	runtimes := []struct {
+		name string
+		pc   concrete.Precompile
+	}{
+		{"wazero", NewWazeroPrecompile(errCode)},
+		{"wasmer", NewWasmerPrecompile(errCode)},
+	}
+	for _, runtime := range runtimes {
+		t.Run(runtime.name, func(t *testing.T) {
+			env := mock.NewMockEnvironment(common.Address{}, api.EnvConfig{Trusted: true}, true, 0)
+			output, _, err := concrete.RunPrecompile(runtime.pc, env, input, true)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err != api.ErrOutOfGas {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(output) != 0 {
+				t.Fatalf("unexpected output: %x", output)
+			}
+		})
+	}
+}

--- a/concrete/wasm/wasmer.go
+++ b/concrete/wasm/wasmer.go
@@ -161,6 +161,9 @@ func (p *wasmerPrecompile) call_Bytes_BytesErr(expFunc wasmer.NativeFunction, in
 	_retPointer := p.call_Bytes_Uint64(expFunc, input)
 	retPointer := memory.MemPointer(_retPointer)
 	retValues, retErr := memory.GetReturnWithError(p.memory, retPointer, true)
+	if len(retValues) == 0 {
+		return nil, retErr
+	}
 	return retValues[0], retErr
 }
 

--- a/tinygo/precompiles/gas/gas.go
+++ b/tinygo/precompiles/gas/gas.go
@@ -1,0 +1,28 @@
+// Copyright 2023 The concrete-geth Authors
+//
+// The concrete-geth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The concrete library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the concrete library. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"github.com/ethereum/go-ethereum/concrete/e2e"
+	"github.com/ethereum/go-ethereum/tinygo"
+)
+
+func init() {
+	tinygo.WasmWrap(&e2e.GasPrecompile{})
+}
+
+// main is REQUIRED for TinyGo to compile to WASM
+func main() {}


### PR DESCRIPTION
Environment errors triggered by WASM precompiles such as `ErrOutOfGas` should be handled gracefully and not cause concrete-geth to panic. This PR implements and tests the necessary changes to achieve this:
- Return `nil` when WASM returns a `NullPointer` (i.e., 0)
- Recover from Wazero panics and return a `nil` output if `environment.Error() != nil`
- Add a simple `GasPrecompile` fixture and use it to trigger an `ErrOutOfGas` error in WASM and assert it is handled as expected