### PR TITLE
Modify interface and implementation for concrete.enviroment.Create and Create2

### DIFF
--- a/concrete/api/environment.go
+++ b/concrete/api/environment.go
@@ -103,8 +103,8 @@ type Environment interface {
 	Call(address common.Address, data []byte, gas uint64, value *uint256.Int) ([]byte, error)
 	CallDelegate(address common.Address, data []byte, gas uint64) ([]byte, error)
 	// Create
-	Create(data []byte, value *uint256.Int) (common.Address, error)
-	Create2(data []byte, endowment *uint256.Int, salt *uint256.Int) (common.Address, error)
+	Create(data []byte, value *uint256.Int) ([]byte, common.Address, error)
+	Create2(data []byte, endowment *uint256.Int, salt *uint256.Int) ([]byte, common.Address, error)
 }
 
 type EnvConfig struct {
@@ -450,16 +450,16 @@ func (env *Env) CallDelegate(address common.Address, data []byte, gas uint64) ([
 	return output[0], utils.DecodeError(output[1])
 }
 
-func (env *Env) Create(data []byte, value *uint256.Int) (common.Address, error) {
+func (env *Env) Create(data []byte, value *uint256.Int) ([]byte, common.Address, error) {
 	input := [][]byte{data, value.Bytes()}
 	output := env.execute(Create_OpCode, input)
-	return common.BytesToAddress(output[0]), utils.DecodeError(output[1])
+	return output[0], common.BytesToAddress(output[1]), utils.DecodeError(output[2])
 }
 
-func (env *Env) Create2(data []byte, endowment *uint256.Int, salt *uint256.Int) (common.Address, error) {
+func (env *Env) Create2(data []byte, endowment *uint256.Int, salt *uint256.Int) ([]byte, common.Address, error) {
 	input := [][]byte{data, endowment.Bytes(), salt.Bytes()}
 	output := env.execute(Create2_OpCode, input)
-	return common.BytesToAddress(output[0]), utils.DecodeError(output[1])
+	return output[0], common.BytesToAddress(output[1]), utils.DecodeError(output[2])
 }
 
 var _ Environment = (*Env)(nil)

--- a/concrete/api/methods_go.go
+++ b/concrete/api/methods_go.go
@@ -801,10 +801,9 @@ func opCreate(env *Env, args [][]byte) ([][]byte, error) {
 	)
 	gas -= gas / 64
 	env.useGas(gas) // This will always return true since we are using a fraction of the gas left
-	// TODO: return value
-	_, address, gasLeft, err := env.caller.Create(input, gas, value)
+	ret, address, gasLeft, err := env.caller.Create(input, gas, value)
 	env.contract.Gas += gasLeft
-	return [][]byte{address.Bytes(), utils.EncodeError(err)}, nil
+	return [][]byte{ret, address.Bytes(), utils.EncodeError(err)}, nil
 }
 
 func gasCreate2(env *Env, args [][]byte) (uint64, error) {
@@ -830,7 +829,7 @@ func opCreate2(env *Env, args [][]byte) ([][]byte, error) {
 	)
 	gas -= gas / 64
 	env.useGas(gas) // This will always return true since we are using a fraction of the gas left
-	_, address, gasLeft, err := env.caller.Create2(input, gas, value, salt)
+	ret, address, gasLeft, err := env.caller.Create2(input, gas, value, salt)
 	env.contract.Gas += gasLeft
-	return [][]byte{address.Bytes(), utils.EncodeError(err)}, nil
+	return [][]byte{ret, address.Bytes(), utils.EncodeError(err)}, nil
 }


### PR DESCRIPTION
Closes #32 

Create and Create2 are now including the return value of bytecode execution for concrete environment interface.