### PR TITLE
feat: interface check

### DIFF
--- a/concrete/api/interface_go.go
+++ b/concrete/api/interface_go.go
@@ -24,6 +24,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
+	"github.com/ethereum/go-ethereum/core/interfaces"
+	//cc_api "github.com/ethereum/go-ethereum/concrete/api"
 )
 
 type StateDB interface {

--- a/core/interfaces/state_db.go
+++ b/core/interfaces/state_db.go
@@ -1,0 +1,34 @@
+package interfaces
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+type StateDB interface {
+	// Access list
+	AddressInAccessList(addr common.Address) bool
+	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
+	AddAddressToAccessList(addr common.Address)
+	AddSlotToAccessList(addr common.Address, slot common.Hash)
+	// Code
+	GetCode(common.Address) []byte
+	GetCodeSize(common.Address) int
+	GetCodeHash(common.Address) common.Hash
+	// Balance
+	GetBalance(addr common.Address) *uint256.Int
+	// Logs
+	AddLog(*types.Log)
+	// Refunds
+	AddRefund(uint64)
+	SubRefund(uint64)
+	GetRefund() uint64
+	// Storage
+	GetCommittedState(addr common.Address, key common.Hash) common.Hash
+	SetState(addr common.Address, key common.Hash, value common.Hash)
+	GetState(addr common.Address, key common.Hash) common.Hash
+	// Storage -- Concrete
+	// SetEphemeralState(addr common.Address, key common.Hash, value common.Hash)
+	// GetEphemeralState(addr common.Address, key common.Hash) common.Hash
+}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -24,7 +24,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/concrete"
-	cc_api "github.com/ethereum/go-ethereum/concrete/api"
+	//cc_api "github.com/ethereum/go-ethereum/concrete/api"
+	"github.com/ethereum/go-ethereum/core/interfaces"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -1434,4 +1435,5 @@ func copy2DSet[k comparable](set map[k]map[common.Hash][]byte) map[k]map[common.
 	return copied
 }
 
-var _ cc_api.StateDB = (*StateDB)(nil)
+//var _ cc_api.StateDB = (*StateDB)(nil)
+var _ interfaces.StateDB = (*StateDB)(nil)


### PR DESCRIPTION
Move the Interface Check: Here we relocated the interface check from its current location in "statedb.go" to a different place, suggested as "concrete/api/interface_go.go." This step is essential for decoupling the dependency between "core/state" and "concrete."